### PR TITLE
Fix a bad import path

### DIFF
--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -19,7 +19,7 @@ import { ResponseObject } from '@hapi/hapi';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityPluginConfigType } from '..';
 import { GLOBAL_TENANT_SYMBOL, PRIVATE_TENANT_SYMBOL, globalTenantName } from '../../common';
-import { modifyUrl } from '../../../../packages/osd-std';
+import { modifyUrl } from '@osd/std';
 import { ensureRawRequest } from '../../../../src/core/server/http/router';
 import { GOTO_PREFIX } from '../../../../src/plugins/share/common/short_url_routes';
 


### PR DESCRIPTION
### Description
Found a case where the import was done using a relative reference, instead of using a package reference causing a build break in some circumstances.

### Issues Resolved
- Resolves #1487

### Testing
Using relative path import is fundamentally wrong, as long as CI works this fix works.  Verified that there are no other references to `../packages/` in the codebase as well.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).